### PR TITLE
allowing for binary expressions as function bodies in arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,12 @@ module.exports = function(code) {
       }
 
       content += "{\n";
-      content += func_contents;
+      if (node.body.type === 'BinaryExpression') {
+        // x => x * 2
+        content += "return " + func_contents + ";\n";
+      } else {
+        content += func_contents;
+      }
       content += "}\n";
 
     } else if (node.type == "ObjectExpression") {

--- a/test/fixtures/arrow_functions.js
+++ b/test/fixtures/arrow_functions.js
@@ -1,3 +1,4 @@
 var something = (a, b = 2, c = 4) => {
   return a * b * c;
 }
+var something2 = (a, b = 2, c = 4) => a * b * c;

--- a/test/fixtures/arrow_functions.php
+++ b/test/fixtures/arrow_functions.php
@@ -3,3 +3,7 @@ $something = function ($a, $b = 2, $c = 4) {
 return $a * $b * $c;
 }
 ;
+$something2 = function ($a, $b = 2, $c = 4) {
+return $a * $b * $c;
+}
+;


### PR DESCRIPTION
`dbl = x => x * 2` was compilling to:

```php
$dbl = function($x) {
$x * 2
}
```

but should have compiled to:
```php
$dbl = function($x)  {
return $x * 2;
}
```