### PR TITLE
handling calling parent constructor and assignment of $this->prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = function(code) {
       }
 
     } else if (node.type == "AssignmentExpression" ||
-               node.type == "AssignmentPattern") {
+      node.type == "AssignmentPattern") {
       scope.get(node).register(node.left);
 
       content = visit(node.left, node) + " " + (node.operator || "=") + " " + visit(node.right, node);
@@ -163,7 +163,11 @@ module.exports = function(code) {
       node.callee.isCallee = (!calleeDefined || calleeDefined && (calleeDefined.type != "Identifier" &&
                                                                   calleeDefined.type != "VariableDeclarator"));
 
-      content += visit(node.callee, node);
+      if (node.callee.type === 'Super') {
+        content += 'parent::__construct';
+      } else {
+        content += visit(node.callee, node);
+      }
 
       // inline anonymous call
       if ((node.callee.isCallee && node.callee.type == "FunctionDeclaration") ||

--- a/scope.js
+++ b/scope.js
@@ -38,7 +38,8 @@ function Scope(root, parent) {
 
     } else if (node.type == 'Identifier') {
       name = node.name;
-
+    } else if (node.type === 'MemberExpression'&& node.object.type === 'ThisExpression' && node.property.type === 'Identifier') {
+      name = node.property.name
     } else if (node.type == 'MethodDefinition') {
       if (node.kind == "get") {
         var getter = utils.clone(node);

--- a/test/fixtures/class_inheritance.js
+++ b/test/fixtures/class_inheritance.js
@@ -1,9 +1,24 @@
-class Page { }
+class Page {
+  constructor(title, body) {
+    this.title = title
+    this.body = body
+  }
+
+  getDescription() {
+    return `${this.title}: ${this.body}`
+  }
+}
 class Article extends Page {
-  constructor(name) {
-    this.name = name;
+  constructor(title, body, author) {
+    super(title, body)
+    this.author = author
+  }
+
+  getDescription() {
+    let descrition = parent.getDescription()
+    return `${description} by ${this.author}`
   }
 }
 
-var article = new Article("Wonderful article");
-var_dump(article.name);
+var article = new Article("Wonderful article", "Yada Yada Yada", "Bob Loblaw");
+var_dump(article.getDescription());

--- a/test/fixtures/class_inheritance.php
+++ b/test/fixtures/class_inheritance.php
@@ -1,15 +1,30 @@
 <?php
 class Page
 {
+public $title;
+public $body;
+public function __construct($title, $body) {
+$this->title = $title;
+$this->body = $body;
+}
+public function getDescription() {
+return "{$this->title}: {$this->body}";
+}
 
 }
 class Article extends Page
 {
-public $name;
-public function __construct($name) {
-$this->name = $name;
+public $author;
+public function __construct($title, $body, $author) {
+parent::__construct($title, $body);
+$this->author = $author;
+}
+public function getDescription() {
+$descrition = $parent->getDescription();
+return "{$description} by {$this->author}";
 }
 
 }
-$article = new Article("Wonderful article");
-var_dump($article->name);
+$article = new Article("Wonderful article", "Yada Yada Yada", "Bob Loblaw");
+var_dump($article->getDescription());
+


### PR DESCRIPTION
FIX: $this->prop =  now causes a public $prop variable to be declared. It wasn't catching them all when multiple ones were being done.

FIX: constructors calling the parent constructor using the `super(...)` syntax wasn't getting expanded to `parent::__construct(...)`