### PR TITLE
split fixes

### DIFF
--- a/core/string.js
+++ b/core/string.js
@@ -125,6 +125,11 @@ module.exports = {
       args[0].raw = "'/" + regex + "/" + flags.replace("g", "") + "'";
       args[0].type = "Literal";
     }
+    // If splitting with a blank delimiter, use str_split.
+    else if (args[0].value === '') {
+      method = "str_split";
+      args = [args[1]];
+    }
 
     return {
       type: 'CallExpression',

--- a/core/string.js
+++ b/core/string.js
@@ -109,7 +109,7 @@ module.exports = {
   },
 
   split: function(node) {
-    var method = "split";
+    var method = "explode";
     var args = utils.clone(node.parent.arguments);
     args.push(node.parent.callee.object);
 

--- a/test/fixtures/core_string.js
+++ b/test/fixtures/core_string.js
@@ -21,6 +21,10 @@ echo(replace_stuff.replace(str, 'Goodnight'));
 var replace_stuff2 = 'say Hello';
 echo(replace_stuff2.replace('say', str));
 
+var strArray = str.split('ll');
+echo(strArray[0]);
+
+
 if (str.match(/endel/)) {
   var_dump(str);
 }

--- a/test/fixtures/core_string.js
+++ b/test/fixtures/core_string.js
@@ -21,8 +21,13 @@ echo(replace_stuff.replace(str, 'Goodnight'));
 var replace_stuff2 = 'say Hello';
 echo(replace_stuff2.replace('say', str));
 
+// test explode
 var strArray = str.split('ll');
 echo(strArray[0]);
+
+// test str_split
+var strArray2 = str.split('');
+echo(strArray2[0]);
 
 
 if (str.match(/endel/)) {

--- a/test/fixtures/core_string.php
+++ b/test/fixtures/core_string.php
@@ -13,6 +13,8 @@ $replace_stuff = 'say Hello';
 echo(str_replace($str, 'Goodnight', $replace_stuff));
 $replace_stuff2 = 'say Hello';
 echo(str_replace('say', $str, $replace_stuff2));
+$strArray = explode('ll', $str);
+echo($strArray[0]);
 if (preg_match('/endel/', $str)) {
 var_dump($str);
 }

--- a/test/fixtures/core_string.php
+++ b/test/fixtures/core_string.php
@@ -15,6 +15,8 @@ $replace_stuff2 = 'say Hello';
 echo(str_replace('say', $str, $replace_stuff2));
 $strArray = explode('ll', $str);
 echo($strArray[0]);
+$strArray2 = str_split($str);
+echo($strArray2[0]);
 if (preg_match('/endel/', $str)) {
 var_dump($str);
 }

--- a/test/fixtures/regexp.php
+++ b/test/fixtures/regexp.php
@@ -3,7 +3,7 @@ $one = preg_match('/llo/', "Hello");
 var_dump($one);
 $two = preg_match_all('/llo/', "Hello");
 var_dump($two);
-$splitted = split(",", "one, two, three");
+$splitted = explode(",", "one, two, three");
 var_dump($splitted);
 $splitted = preg_split('/,/', "one, two, three");
 var_dump($splitted);


### PR DESCRIPTION
Split PHP function is depricated, use explode instead.
Also added conversion from split to str_split when a blank string is given as the delimiter as explode does not allow a blank delimiter.
eg
`'mystring'.split("st")` will be converted to explode
`'mystring'.split("")` will be converted to str_split