### PR TITLE
access to global scope from functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var core = require('./core'),
-    scope = require('./scope'),
-    utils = require('./utils'),
-    espree = require('espree');
+  scope = require('./scope'),
+  utils = require('./utils'),
+  espree = require('espree');
 
-module.exports = function(code) {
+module.exports = function (code) {
   var ast = espree.parse(code, {
-    loc : true,
-    range : true,
-    tokens : true,
-    comment : true,
+    loc: true,
+    range: true,
+    tokens: true,
+    comment: true,
     ecmaFeatures: {
       arrowFunctions: true, // enable parsing of arrow functions
       blockBindings: true, // enable parsing of let/const
@@ -48,13 +48,13 @@ module.exports = function(code) {
 
     if (node.type == "Program" || node.type == "BlockStatement" || node.type == "ClassBody") {
 
-      for (var i=0,length = node.body.length;i<length;i++) {
+      for (var i = 0, length = node.body.length; i < length; i++) {
         content += visit(node.body[i], node);
       }
 
     } else if (node.type == "VariableDeclaration") {
       // declaration of one or multiple variables
-      for (var i=0,length=node.declarations.length;i<length;i++) {
+      for (var i = 0, length = node.declarations.length; i < length; i++) {
         content += visit(node.declarations[i], node);
       }
 
@@ -171,8 +171,10 @@ module.exports = function(code) {
 
       // inline anonymous call
       if ((node.callee.isCallee && node.callee.type == "FunctionDeclaration") ||
-        node.type == "ArrowFunctionExpression") {
+        node.type == "ArrowFunctionExpression" || node.type === "FunctionExpression") {
         var identifier = null;
+        node.id = { name: node.id || "" };
+
         if (node.parent.type == "VariableDeclarator") {
           // var something = (function() { return 0; })();
           identifier = node.parent.id.name;
@@ -186,8 +188,8 @@ module.exports = function(code) {
       if (node.arguments) {
         var arguments = [];
 
-        for (var i=0, length = node.arguments.length; i < length; i++) {
-          arguments.push( visit(node.arguments[i], node) );
+        for (var i = 0, length = node.arguments.length; i < length; i++) {
+          arguments.push(visit(node.arguments[i], node));
         }
 
         content += "(" + arguments.join(', ') + ")";
@@ -238,6 +240,7 @@ module.exports = function(code) {
       }
 
     } else if (node.type == "FunctionDeclaration" ||
+      node.type === 'FunctionExpression' ||
       node.type == "ArrowFunctionExpression") {
       var param,
         parameters = [],
@@ -247,7 +250,7 @@ module.exports = function(code) {
       scope.create(node);
 
       // compute function params
-      for (var i=0; i < node.params.length; i++) {
+      for (var i = 0; i < node.params.length; i++) {
         if (defaults[i]) {
           param = visit({
             type: "BinaryExpression",
@@ -275,13 +278,20 @@ module.exports = function(code) {
 
       // try to use parent's variables
       // http://php.net/manual/pt_BR/functions.anonymous.php
-      if (using.length > 0) {
-        content += "use (" + using.map(function(identifier) {
+      if (using.length > 0 && node.type !== 'FunctionDeclaration') {
+        content += "use (" + using.map(function (identifier) {
           return "&$" + identifier;
         }).join(', ') + ") ";
       }
 
       content += "{\n";
+      if (using.length > 0 && node.type === 'FunctionDeclaration') {
+        console.log(using, node)
+        content += using.map(function (identifier) {
+          return "global $" + identifier;
+        }).join('\n');
+      }
+
       if (node.body.type === 'BinaryExpression') {
         // x => x * 2
         content += "return " + func_contents + ";\n";
@@ -292,21 +302,21 @@ module.exports = function(code) {
 
     } else if (node.type == "ObjectExpression") {
       var properties = [];
-      for (var i=0; i < node.properties.length; i++) {
-        properties.push( visit(node.properties[i], node) )
+      for (var i = 0; i < node.properties.length; i++) {
+        properties.push(visit(node.properties[i], node))
       }
       content = "array(" + properties.join(", ") + ")";
 
     } else if (node.type == "ArrayExpression") {
       var elements = [];
-      for (var i=0; i < node.elements.length; i++) {
-        elements.push( visit(node.elements[i], node) )
+      for (var i = 0; i < node.elements.length; i++) {
+        elements.push(visit(node.elements[i], node))
       }
       content = "array(" + elements.join(", ") + ")";
 
     } else if (node.type == "Property") {
       var property = (node.key.type == 'Identifier') ? node.key.name : node.key.value;
-      content = '"'+property+'" => ' + visit(node.value, node);
+      content = '"' + property + '" => ' + visit(node.value, node);
 
     } else if (node.type == "ReturnStatement") {
       semicolon = true;
@@ -329,8 +339,8 @@ module.exports = function(code) {
 
       if (s.getters.length > 0) {
         content += "function __get($_property) {\n";
-        for (var i=0;i<s.getters.length;i++) {
-          content += "if ($_property === '"+s.getters[i].key.name+"') {\n";
+        for (var i = 0; i < s.getters.length; i++) {
+          content += "if ($_property === '" + s.getters[i].key.name + "') {\n";
           content += visit(s.getters[i].value.body, node);
           content += "}\n";
         }
@@ -339,8 +349,8 @@ module.exports = function(code) {
 
       if (s.setters.length > 0) {
         content += "function __set($_property, $value) {\n";
-        for (var i=0;i<s.setters.length;i++) {
-          content += "if ($_property === '"+s.setters[i].key.name+"') {\n";
+        for (var i = 0; i < s.setters.length; i++) {
+          content += "if ($_property === '" + s.setters[i].key.name + "') {\n";
           content += visit(s.setters[i].value.body, node);
           content += "}\n";
         }
@@ -371,7 +381,7 @@ module.exports = function(code) {
       if (isConstructor) {
         node.key.name = "__construct";
         var definitions = scope.get(node.value).definitions;
-        for(var i in definitions) {
+        for (var i in definitions) {
           if (definitions[i] && definitions[i].type == "MemberExpression") {
             definitions[i].property.isMemberExpression = false;
             content += "public " + visit(definitions[i].property, null) + ";\n";
@@ -392,14 +402,14 @@ module.exports = function(code) {
       content = "parent";
 
     } else if (node.type == "IfStatement") {
-      content = "if ("+visit(node.test, node)+") {\n";
+      content = "if (" + visit(node.test, node) + ") {\n";
       content += visit(node.consequent, node) + "}";
 
       if (node.alternate) {
         content += " else ";
 
         if (node.alternate.type == "BlockStatement") {
-          content += "{"+visit(node.alternate, node)+"}";
+          content += "{" + visit(node.alternate, node) + "}";
 
         } else {
           content += visit(node.alternate, node)
@@ -409,8 +419,8 @@ module.exports = function(code) {
     } else if (node.type == "SequenceExpression") {
       var expressions = [];
 
-      for (var i=0;i<node.expressions.length;i++) {
-        expressions.push( visit(node.expressions[i], node) );
+      for (var i = 0; i < node.expressions.length; i++) {
+        expressions.push(visit(node.expressions[i], node));
       }
 
       content = expressions.join(', ') + ";";
@@ -431,14 +441,14 @@ module.exports = function(code) {
     } else if (node.type == "ForStatement") {
       content = "for (";
       content += visit(node.init, node);
-      content += visit(node.test, node) + ";" ;
+      content += visit(node.test, node) + ";";
       content += visit(node.update, node);
       content += ") {";
       content += visit(node.body, node);
       content += "}";
 
     } else if (node.type == "ForInStatement" || node.type == "ForOfStatement") {
-      content = "foreach (" + visit(node.right, node) + " as " + visit(node.left, node)+ " => $___)";
+      content = "foreach (" + visit(node.right, node) + " as " + visit(node.left, node) + " => $___)";
       content += "{" + visit(node.body, node) + "}";
 
     } else if (node.type == "UpdateExpression") {
@@ -456,7 +466,7 @@ module.exports = function(code) {
     } else if (node.type == "SwitchStatement") {
       content = "switch (" + visit(node.discriminant, node) + ")";
       content += "{";
-      for (var i=0; i < node.cases.length; i++) {
+      for (var i = 0; i < node.cases.length; i++) {
         content += visit(node.cases[i], node) + "\n";
       }
       content += "}";
@@ -466,10 +476,10 @@ module.exports = function(code) {
       if (node.test) {
         content += "case " + visit(node.test, node) + ":\n";
       } else {
-        content =  "default:\n";
+        content = "default:\n";
       }
 
-      for (var i=0; i < node.consequent.length; i++) {
+      for (var i = 0; i < node.consequent.length; i++) {
         content += visit(node.consequent[i], node);
       }
 
@@ -483,13 +493,13 @@ module.exports = function(code) {
 
       return "new " + visit(newNode, node);
 
-    } else if (node.type == "FunctionExpression") {
-
-      // Re-use FunctionDeclaration structure for method definitions
-      node.type = "FunctionDeclaration";
-      node.id = { name: node.id || "" };
-
-      content = visit(node, node.parent);
+      /*} else if (node.type == "FunctionExpression") {
+  
+        // Re-use FunctionDeclaration structure for method definitions
+        node.type = "FunctionDeclaration";
+        node.id = { name: node.id || "" };
+  
+        content = visit(node, node.parent);*/
 
 
       // Modules & Export (http://wiki.ecmascript.org/doku.php?id=harmony:modules_examples)
@@ -501,7 +511,7 @@ module.exports = function(code) {
       content = visit(node.declaration, node);
 
     } else if (node.type == "ImportDeclaration") {
-      for (var i=0,length = node.specifiers.length;i<length;i++) {
+      for (var i = 0, length = node.specifiers.length; i < length; i++) {
         content += visit(node.specifiers[i], node);
       }
 
@@ -517,12 +527,12 @@ module.exports = function(code) {
     } else if (node.type == "TemplateLiteral") {
       var expressions = node.expressions
         , quasis = node.quasis
-        , nodes = quasis.concat(expressions).sort(function(a, b) {
+        , nodes = quasis.concat(expressions).sort(function (a, b) {
           return b.range[0] < a.range[0];
         })
         , cooked = "";
 
-      for (var i=0; i<nodes.length; i++) {
+      for (var i = 0; i < nodes.length; i++) {
         if (nodes[i].type == "TemplateElement") {
           cooked += nodes[i].value.cooked;
         } else {
@@ -544,7 +554,7 @@ module.exports = function(code) {
       if (node.finalizer) {
         content += " finally {\n";
         content += visit(node.finalizer, node);
-	      content += "}\n";
+        content += "}\n";
       }
 
     } else if (node.type === "CatchClause") {

--- a/index.js
+++ b/index.js
@@ -286,7 +286,6 @@ module.exports = function (code) {
 
       content += "{\n";
       if (using.length > 0 && node.type === 'FunctionDeclaration') {
-        console.log(using, node)
         content += using.map(function (identifier) {
           return "global $" + identifier;
         }).join('\n');

--- a/js2php
+++ b/js2php
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 
 var fs = require('fs'),
-    js2php = require('./index.js');
+  js2php = require('./index.js');
 
 if (process.stdin.isTTY) {
 
-  if (process.argv[2]=="-v" || process.argv[2]=="--version") {
+  if (process.argv[2] == "-v" || process.argv[2] == "--version") {
     console.log(require('./package.json').version);
 
   } else {
-    console.log(  js2php(fs.readFileSync(process.argv[2]).toString()) );
+    console.log(js2php(fs.readFileSync(process.argv[2]).toString()));
   }
 
 } else {
-  var code = "";
+  var code = [];
   process.stdin.resume();
-  process.stdin.on('data', function(data) { code += data; });
-  process.stdin.on('end', function() {
-    console.log( js2php(code) );
+  process.stdin.on('data', function (data) { code.push(data); });
+  process.stdin.on('end', function () {
+    console.log(js2php(code.join('')));
   });
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "type": "git",
     "url": "https://github.com/endel/js2php.git"
   },
-  "keywords": [ "javascript", "php", "transpiler", "transcompiler" ],
+  "keywords": [
+    "javascript",
+    "php",
+    "transpiler",
+    "transcompiler"
+  ],
   "devDependencies": {
     "browserify": "~6.0.*",
     "mocha": "~2.0.1",

--- a/test/fixtures/anonymous_function.php
+++ b/test/fixtures/anonymous_function.php
@@ -2,12 +2,13 @@
 $inline = function ($i) {
 return $i;
 }
-;$inline = $inline(5);
+(5);
 var_dump($inline);
 $assignment = null;
 $assignment = function () {
 $_results = array(1, 2, 3, 4, 5);
 return $_results;
 }
-;$assignment = $assignment();
+();
 var_dump($assignment);
+

--- a/test/fixtures/function.js
+++ b/test/fixtures/function.js
@@ -11,7 +11,13 @@ function hello(a, b) {
   return "hello!";
 }
 
-var_dump(hello.apply(hello, [5,6]))
-var_dump(hello(5, 6))
+let total = 0
+function add(x) {
+  total += x
+}
 
-// var_dump(something(5), sum(1,2))
+var_dump(hello.apply(hello, [5, 6]))
+var_dump(hello(5, 6))
+add(1);
+add(2);
+var_dump($total);

--- a/test/fixtures/function.php
+++ b/test/fixtures/function.php
@@ -8,5 +8,13 @@ return $a + $b;
 function hello($a, $b) {
 return "hello!";
 }
+$total = 0;
+function add($x) {
+$total += $x;
+}
 var_dump(call_user_func_array('hello', array(5, 6)));
 var_dump(hello(5, 6));
+add(1);
+add(2);
+var_dump($$total);
+

--- a/test/suite.js
+++ b/test/suite.js
@@ -1,20 +1,20 @@
 var assert = require("assert"),
-    fs = require('fs'),
-    js2php = require('../index.js'),
-    fixturesPath = './test/fixtures/',
-    fixtures = fs.readdirSync(fixturesPath).filter(function(file) { return !file.match(/~$/) }),
-    sources = [];
+  fs = require('fs'),
+  js2php = require('../index.js'),
+  fixturesPath = './test/fixtures/',
+  fixtures = fs.readdirSync(fixturesPath).filter(function (file) { return !file.match(/~$/) }),
+  sources = [];
 
-for(var i=0;i<fixtures.length;i+=2) {
-  sources.push([fixturesPath + fixtures[i], fixturesPath + fixtures[i+1]])
+for (var i = 0; i < fixtures.length; i += 2) {
+  sources.push([fixturesPath + fixtures[i], fixturesPath + fixtures[i + 1]])
 }
 
-describe('js2php', function(){
-  for(var i=0;i<sources.length;i++) {
-    (function(i) {
-      it(sources[i][0], function(){
-        var js_source = fs.readFileSync(sources[i][0]).toString(),
-        php_source = fs.readFileSync(sources[i][1]).toString().trim();
+describe('js2php', function () {
+  for (var i = 0; i < sources.length; i++) {
+    (function (i) {
+      it(sources[i][0], function () {
+        var js_source = fs.readFileSync(sources[i][0]).toString();
+        var php_source = fs.readFileSync(sources[i][1]).toString().trim();
 
         assert.equal(js2php(js_source).trim(), php_source);
       })


### PR DESCRIPTION
Given the following JavaScript the PHP generated was malformed:
```js
const total = 0
function add(x) {
  total += x
}
```

Produced this PHP:
```php
$total = 0;
function add($x) use (&$total) {
$total += $x;
}
```
Unfortunately `use` is not allowed to be used on FunctionDeclarations anything other than an so to make the above work I've made FunctionDeclarations use the `global` keyword instead:
```php
$total = 0;
function add($x) {
global $total;
$total += $x;
}
```

At the same time I found a bug with function expressions, as opposed to Arrow Functions that produced the wrong code too. Those now use the `use` keyword too.

