### PR TITLE
regex fix, string concat fix, string.length workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ What does it converts?
   - Function
     - Function.prototype.apply
     - Function.prototype.call
-  - Date (missing)
+  - Date
+    - Date.now
 
 Testing
 ---

--- a/core/array.js
+++ b/core/array.js
@@ -130,7 +130,9 @@ module.exports = {
     var targetDefinition = scope.get(node).getDefinition(object);
 
     if (!isString && targetDefinition) {
-      if (targetDefinition.dataType == "String") {
+      if (targetDefinition.type == "Identifier" && targetDefinition.name == "string") {
+        isString = true;
+      } else if (targetDefinition.dataType == "String") {
         isString = true;
       } else if(targetDefinition.type == "Identifier" && targetDefinition.parent.type == "AssignmentExpression") {
         isString = utils.isString(targetDefinition.parent.right);

--- a/core/array.js
+++ b/core/array.js
@@ -125,16 +125,23 @@ module.exports = {
   length: function(node) {
     var method,
         object = (node.parent.callee && node.parent.callee.object) || node.object,
-        isString = (object.type=='Literal' && object.raw.match(/^['|"]/));
+        isString = utils.isString(object);
 
     var targetDefinition = scope.get(node).getDefinition(object);
-    if (utils.isString(object) || (targetDefinition && targetDefinition.dataType == "String")) {
-      method = "strlen";
 
+    if (!isString && targetDefinition) {
+      if (targetDefinition.dataType == "String") {
+        isString = true;
+      } else if(targetDefinition.type == "Identifier" && targetDefinition.parent.type == "AssignmentExpression") {
+        isString = utils.isString(targetDefinition.parent.right);
+      }
+    }
+
+    if (isString || (targetDefinition && targetDefinition.dataType == "String")) {
+      method = "strlen";
     } else {
       method = "count";
     }
-
 
     return {
       type: 'CallExpression',

--- a/core/string.js
+++ b/core/string.js
@@ -161,17 +161,21 @@ module.exports = {
     var args = utils.clone(node.parent.arguments);
     args.push(node.parent.callee.object);
 
-    var regexpData = args[0].raw.match(/^\/([^\/]+)\/([gimy])?$/),
-        regex = regexpData && regexpData[1],
-        flags = regexpData && regexpData[2] || "",
-        isGroup = flags.indexOf('g') >= 0;
+    if(args[0].type === 'Literal') {
 
-    // remove unsupported /g from regexp, to use preg_match_all
-    if (isGroup) { flags = flags.replace("g", ""); }
-    regex = "/" + regex + "/" + flags;
+      var regexpData = args[0].raw.match(/^\/([^\/]+)\/([gimy])?$/),
+          regex = regexpData && regexpData[1],
+          flags = regexpData && regexpData[2] || "",
+          isGroup = flags.indexOf('g') >= 0;
 
-    args[0].raw = "'" + regex + "'";
-    args[0].type = "Literal";
+      // remove unsupported /g from regexp, to use preg_match_all
+      if (isGroup) { flags = flags.replace("g", ""); }
+      regex = "/" + regex + "/" + flags;
+
+      args[0].raw = "'" + regex + "'";
+      args[0].type = "Literal";
+
+    }
 
     node.parent.arguments = false;
 
@@ -183,6 +187,7 @@ module.exports = {
       },
       arguments: args
     };
+
   },
 
 }

--- a/index.js
+++ b/index.js
@@ -110,6 +110,18 @@ module.exports = function(code) {
         }, node);
 
       } else {
+
+        // test for two strings.
+        var leftDefinition = scope.get(node).getDefinition(node.left);
+        var rightDefinition = scope.get(node).getDefinition(node.right);
+
+        if (leftDefinition && rightDefinition) {
+          if (leftDefinition.type == "VariableDeclarator" && rightDefinition.type == "VariableDeclarator") {
+            if (utils.isString(leftDefinition.init) && utils.isString(rightDefinition.init)) {
+              node.operator = node.operator.replace('+', '.');
+            }
+          }
+        }
         content = visit(node.left, node) + " " + node.operator + " " + visit(node.right, node);
       }
 

--- a/test/fixtures/closures.php
+++ b/test/fixtures/closures.php
@@ -2,7 +2,7 @@
 $d = 10;
 $closure = function ($a) use (&$d) {
 $c = 1;
-return function ($b) use (&$a, &$c, &$d) {
+return function ($b) use (&$d, &$c, &$a) {
 return $a + $b + $c + $d;
 }
 ;

--- a/test/fixtures/concat.js
+++ b/test/fixtures/concat.js
@@ -1,0 +1,4 @@
+var string1 = "string1";
+var string2 = "string2";
+var string3 = string1 + string2;
+var_dump(string1+string2);

--- a/test/fixtures/concat.php
+++ b/test/fixtures/concat.php
@@ -1,0 +1,5 @@
+<?php
+$string1 = "string1";
+$string2 = "string2";
+$string3 = $string1 . $string2;
+var_dump($string1 . $string2);

--- a/test/fixtures/core_string.js
+++ b/test/fixtures/core_string.js
@@ -44,7 +44,6 @@ lengthTest1('hmm');
 var temp = 'hmmm';
 lengthTest2(temp);
 
-
 if (str.match(/endel/)) {
   var_dump(str);
 }

--- a/test/fixtures/core_string.js
+++ b/test/fixtures/core_string.js
@@ -29,7 +29,14 @@ echo(strArray[0]);
 var strArray2 = str.split('');
 echo(strArray2[0]);
 
+var_dump('testing'.length);
+
+test_length = 'testing_string_variable';
+var_dump(test_length.length);
+
 
 if (str.match(/endel/)) {
   var_dump(str);
 }
+
+

--- a/test/fixtures/core_string.js
+++ b/test/fixtures/core_string.js
@@ -31,8 +31,18 @@ echo(strArray2[0]);
 
 var_dump('testing'.length);
 
-test_length = 'testing_string_variable';
+var test_length = 'testing_string_variable';
 var_dump(test_length.length);
+
+function lengthTest1(string) {
+  var_dump(string.length);
+}
+function lengthTest2(string) {
+  var_dump(string.length);
+}
+lengthTest1('hmm');
+var temp = 'hmmm';
+lengthTest2(temp);
 
 
 if (str.match(/endel/)) {

--- a/test/fixtures/core_string.php
+++ b/test/fixtures/core_string.php
@@ -20,6 +20,15 @@ echo($strArray2[0]);
 var_dump(strlen('testing'));
 $test_length = 'testing_string_variable';
 var_dump(strlen($test_length));
+function lengthTest1($string) {
+var_dump(strlen($string));
+}
+function lengthTest2($string) {
+var_dump(strlen($string));
+}
+lengthTest1('hmm');
+$temp = 'hmmm';
+lengthTest2($temp);
 if (preg_match('/endel/', $str)) {
 var_dump($str);
 }

--- a/test/fixtures/core_string.php
+++ b/test/fixtures/core_string.php
@@ -17,6 +17,9 @@ $strArray = explode('ll', $str);
 echo($strArray[0]);
 $strArray2 = str_split($str);
 echo($strArray2[0]);
+var_dump(strlen('testing'));
+$test_length = 'testing_string_variable';
+var_dump(strlen($test_length));
 if (preg_match('/endel/', $str)) {
 var_dump($str);
 }

--- a/test/fixtures/regexp.js
+++ b/test/fixtures/regexp.js
@@ -17,3 +17,7 @@ var_dump("hey".replace("y", "llo"));
 var_dump("hey".replace(/y/, "llo"));
 var_dump("hey hey hey".replace(/y/, "llo"));
 var_dump("hey hey hey".replace(/y/g, "llo"));
+
+var string = 'hello';
+var regex = 'ello';
+var nonliteral = string.match(regex);

--- a/test/fixtures/regexp.php
+++ b/test/fixtures/regexp.php
@@ -13,3 +13,6 @@ var_dump(str_replace("y", "llo", "hey"));
 var_dump(preg_replace('/y/', "llo", "hey", 1));
 var_dump(preg_replace('/y/', "llo", "hey hey hey", 1));
 var_dump(preg_replace('/y/', "llo", "hey hey hey"));
+$string = 'hello';
+$regex = 'ello';
+$nonliteral = preg_match($regex, $string);


### PR DESCRIPTION
fix for #28 
fix for #26 
fix and workaround for #30 (if a variables type can't be determined, but is named "string", it is assumed to be a string when .length is called).